### PR TITLE
Feature: better span count threshold in EmojiGrid.

### DIFF
--- a/EmojiKeyboard/src/main/java/com/imbox/emojikeyboard/ui/view/components/EmojiGrid.kt
+++ b/EmojiKeyboard/src/main/java/com/imbox/emojikeyboard/ui/view/components/EmojiGrid.kt
@@ -91,7 +91,7 @@ internal class EmojiGrid(context: Context, private val delegate: EmojiDelegate) 
     private fun calculateSpanForHeight(heightPx: Int): Int {
         val heightDp = heightPx.px
         return when {
-            heightDp < 200 -> 3
+            heightDp < 180 -> 3
             heightDp < 240 -> 4
             heightDp < 280 -> 5
             else -> 6


### PR DESCRIPTION
Span count range for 4 rows in horizontal layout modes (like COOPER) had a lower bound too high that in some devices, span count jumped to 3 showing huge emojis.

I have lowered the threshold from 200dp to 180dp. Fixes #8.